### PR TITLE
ability to control whether set ie proxy on startup, ieproxy=0/1

### DIFF
--- a/fwlite_gui/mainw.py
+++ b/fwlite_gui/mainw.py
@@ -116,9 +116,11 @@ class MainWindow(QMainWindow):
         self.conf.read(self.path_to_conf)
         listen = self.conf['FWLite'].get('listen', '8118')
         port = int(listen) if listen.isdigit() else int(listen.split(':')[1])
+        self.ieproxy = int(self.conf['FWLite'].get('ieproxy', '1'))
+        
         if port != self.port:
             self.port = port
-            if sys.platform.startswith('win'):
+            if sys.platform.startswith('win') and self.ieproxy == 1:
                 setIEproxy(1, u'127.0.0.1:%d' % self.port)
 
         _pass = self.conf['FWLite'].get('remotepass', None)

--- a/fwlite_gui/systray.py
+++ b/fwlite_gui/systray.py
@@ -80,7 +80,8 @@ class SystemTrayIcon(QSystemTrayIcon):
 
         if sys.platform.startswith('win'):
 
-            setIEproxy(1, u'127.0.0.1:%d' % self.window.port)
+            if self.window.ieproxy == 1:
+                setIEproxy(1, u'127.0.0.1:%d' % self.window.port)
             self.settingIEproxyMenu = self.menu.addMenu(_tr("SystemTrayIcon", "set_proxy"))
             self.settingIEproxyMenu.clear()
 


### PR DESCRIPTION
I don't want fwlite-gui to setup IE proxy setting automatically, thus a setting called "ieproxy" created to control this